### PR TITLE
fix program and significantly refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,8 @@ edition = "2021"
 tokio = {version = "1.29.*", features = ["full"] }
 tokio-tungstenite = "0.20.0"
 futures-util = "0.3.*"
-url = "2.4.*"
 serde = {version = "1.0.105", features = ["derive"]}
 serde_json = "1.0.105"
 rodio = "0.17.1"
-cpal = "0.15.2"
-tempfile = "3.8.0"
 reqwest = "0.11.20"
-uuid = { version = "1.4.1", features = ["v4"] }
+anyhow = "1.0.96"

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,70 +1,38 @@
-// src/audio.rs
+use std::io::Cursor;
+use tokio::sync::mpsc::Receiver;
+use reqwest::get;
+use rodio::{Decoder, Sink};
+use anyhow::{Context, Error};
 
-extern crate reqwest;
-extern crate tempfile;
-extern crate rodio;
-extern  crate uuid;
-
-use std::io::BufReader;
-use std::io::Write;
-use std::fs::File;
-use tempfile::tempdir;
-use rodio::{Decoder, OutputStream, Sink};
-use reqwest::Client;
-use uuid::Uuid;
-
-pub struct AudioPlayer {
-    sink: Sink,
+pub async fn audio_loop(mut rx: Receiver<String>, sink: Sink) -> Result<(), Error> {
+    loop {
+        let input = rx.recv().await
+            .context("Audio channel closed")?;
+        match input.as_str() {
+            "died" => sink.set_volume(0.5),
+            "left" => sink.stop(),
+            _ => play_audio(input, &sink).await?,
+        }
+    }
 }
 
-impl AudioPlayer {
-    pub fn new() -> Self {
-        let (_stream, stream_handle) = OutputStream::try_default().expect("Failed to create audio stream");
-        let sink = Sink::try_new(&stream_handle).expect("Failed to create audio sink");
-        Self { sink }
-    }
+pub async fn play_audio(url: String, sink: &Sink) -> Result<(), Error> {
+    println!("\nGot request to play audio {}", url);
+    // Stop the current playback, if any
+    sink.stop();
 
-    pub async fn play_audio(&self, url: &str) {
-        println!("Balling");
-        // Stop the current playback, if any
-        self.sink.stop();
-        // Create a temporary directory
-    let temp_dir = tempdir().expect("Failed to create temporary directory");
+    // Get response from URL
+    let response = get(url)
+        .await?
+        .bytes()
+        .await?;
 
-    // Generate a unique file name
-    let file_extension = url.split('.').last().unwrap();
-    let file_name = Uuid::new_v4().to_string() + "." + file_extension;
-
-    // Create a reqwest client
-    let client = Client::new();
-
-    // Download the file asynchronously
-    let response = client.get(url).send().await.expect("Failed to send request");
-
-    // Create a file to save the downloaded content
-    let file_path = temp_dir.path().join(&file_name);
-    let mut file = File::create(&file_path).expect("Failed to create file");
-
-    // Save the downloaded content to the file
-    file.write_all(&response.bytes().await.expect("Failed to read response body")).expect("Failed to save file");
-
-    println!("File saved to: {:?}", file_path);
+    println!("Got response");
 
     // Play the downloaded audio
-    let file = File::open(file_path).expect("Failed to open audio file");
-    let decoder = Decoder::new(BufReader::new(file)).expect("Failed to decode audio file");
-    self.sink.append(decoder);
-
-    // Start playback
-    self.sink.play();
+    let cursor = Cursor::new(response);
+    let decoder = Decoder::new(cursor)?;
+    sink.append(decoder);
     println!("Playback started");
-    }
-
-    pub fn set_volume(&self, volume: f32) {
-        self.sink.set_volume(volume);
-    }
-
-    pub fn stop(&self) {
-        self.sink.stop();
-    }
+    Ok(())
 }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,28 +1,30 @@
 use std::io::Cursor;
 use tokio::sync::mpsc::Receiver;
-use reqwest::get;
+use reqwest::Client;
 use rodio::{Decoder, Sink};
 use anyhow::{Context, Error};
 
 pub async fn audio_loop(mut rx: Receiver<String>, sink: Sink) -> Result<(), Error> {
+    let client = Client::new();
     loop {
         let input = rx.recv().await
             .context("Audio channel closed")?;
         match input.as_str() {
             "died" => sink.set_volume(0.5),
             "left" => sink.stop(),
-            _ => play_audio(input, &sink).await?,
+            _ => play_audio(input, &client, &sink).await?,
         }
     }
 }
 
-pub async fn play_audio(url: String, sink: &Sink) -> Result<(), Error> {
+pub async fn play_audio(url: String, client: &Client, sink: &Sink) -> Result<(), Error> {
     println!("\nGot request to play audio {}", url);
     // Stop the current playback, if any
     sink.stop();
 
     // Get response from URL
-    let response = get(url)
+    let response = client.get(url)
+        .send()
         .await?
         .bytes()
         .await?;

--- a/src/json_processor.rs
+++ b/src/json_processor.rs
@@ -1,47 +1,43 @@
-extern crate serde;
-extern crate serde_json;
-
-use super::audio::AudioPlayer;
-
+use tokio::sync::mpsc::Sender;
 use serde::{Deserialize, Serialize};
+use anyhow::{Context, Error};
 
 // Message Format
 #[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct MessageFormat {
-    msgType: String,
-    statusType: Option<String>,
-    audioUrl: Option<String>,
+    msg_type: String,
+    status_type: Option<String>,
+    audio_url: Option<String>,
 }
 
-pub async fn process_data(data: &str, player: &AudioPlayer) {
+pub async fn process_data(data: &str, tx: Sender<String>) -> Result<(), Error> {
     let p_data: MessageFormat = match serde_json::from_str(data) {
         Ok(parsed_data) => parsed_data,
         Err(err) => {
             eprintln!("Error parsing JSON: {}", err);
-            return; // Exit early on error
+            return Err(err.into()); // Exit early on error
         }
     };
 
-    match p_data.msgType.as_str() {
-        "bgm" => {
-            if let Some(audio_url) = &p_data.audioUrl 
-            {
-                player.play_audio(audio_url).await;
-            }
-        },
-        "gameStatus" => {
-            match p_data.statusType.as_deref() {
-                Some("died") => {
-                    player.set_volume(0.5);
-                },
-                Some("left") => {
-                    player.stop();
-                },
-                _ => {} // Handle other status types as needed
-            }
-        },
-        _ => {
-            // Handle unknown message types if necessary
-        }
+    match p_data.msg_type.as_str() {
+        "bgm" => get_audio(p_data, tx).await?,
+        "gameStatus" => get_status(p_data, tx).await?,
+        _ => eprintln!("No msgType was provided"),
     }
+    Ok(())
+}
+
+async fn get_audio(p_data: MessageFormat, tx: Sender<String>) -> Result<(), Error> {
+    let audio_url = p_data.audio_url
+        .context("msgType was bgm but no URL was provided")?;
+    tx.send(audio_url).await?;
+    Ok(())
+}
+
+async fn get_status(p_data: MessageFormat, tx: Sender<String>) -> Result<(), Error> {
+    let status_type = p_data.status_type
+        .context("msgType was gameStatus but no status was provided")?;
+    tx.send(status_type).await?;
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,67 +2,51 @@ mod audio;
 pub mod json_processor;
 
 use std::io::Write;
-use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
 use tokio::task;
+use tokio::sync::mpsc::channel;
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 use futures_util::{StreamExt, SinkExt};
-use cpal::traits::{DeviceTrait, HostTrait};
+use rodio::{OutputStream, Sink};
+use anyhow::{Context, Error};
 
-// Initialize Audio
-
-
-//use url::Url;
 #[tokio::main]
-async fn main() {
-     // Get the default audio host
-     let host = cpal::default_host();
-
-     // Get the default input and output devices
-     let output_device = host.default_output_device().expect("No output device available");
-     println!("Output Device: {:?}", output_device.name().unwrap());
-
+async fn main() -> Result<(), Error> {
     let mut input = String::new();
-    print!("Please enter your Roblox username!: ");
-    std::io::stdout().flush().unwrap();
-    std::io::stdin().read_line(&mut input).expect("Unhandled Exception!");
+    print!("Please enter your Roblox username: ");
+    std::io::stdout().flush()?;
+    std::io::stdin().read_line(&mut input)?;
     let username = input.trim().to_string();
-    println!("Your Roblox username is {}", username);
-    let _ = task::spawn(websocket_connect(username)).await;
+    websocket_connect(username).await?;
+    Ok(())
 }
 
-async fn websocket_connect(username: String) {
-    let url = url::Url::parse("ws://client.fe2.io:8081").unwrap();
+async fn websocket_connect(username: String) -> Result<(), Error> { // this does way more than websocket connect lol
+    let (ws_stream, _response) = connect_async("ws://client.fe2.io:8081").await?;
+    println!("Connection established");
 
-    let (ws_stream, _response) = connect_async(url).await.expect("Failed to connect");
-    println!("Connection Established");
+    let (mut write, mut read) = ws_stream.split();
+    write.send(Message::Text(username)).await?;
 
-    let (mut write, read) = ws_stream.split();
+    println!("Sent username to server");
 
-    println!("sending");
+    let (tx, rx) = channel(2);
+    let (_stream, stream_handle) = OutputStream::try_default()?;
+    let sink = Sink::try_new(&stream_handle)?;
+    task::spawn(audio::audio_loop(rx, sink));
 
-    write.send(Message::Text(username)).await.unwrap();
-
-    println!("sent");
-
-    let player = Arc::new(audio::AudioPlayer::new());
-
-    let read_future = read.for_each(|message| {
-        let player = Arc::clone(&player);
-        async move {
-        
+    loop {
+        let message = read.next().await
+            .context("Couldn't receive messages from server")?;
         println!("receiving...");
-        let data = message.unwrap().into_data();
-        tokio::io::stdout().write(&data).await.unwrap();
+        let data = message?.into_data();
+        tokio::io::stdout().write(&data).await?;
         if let Ok(string_data) = String::from_utf8(data.clone()) {
             println!("received: {}", string_data);
             // Process the data
-            json_processor::process_data(&string_data, &player).await;
+            json_processor::process_data(&string_data, tx.clone()).await?;
         } else {
             println!("received: Invalid UTF-8 data");
         }
-}});
-    
-
-    read_future.await;
+    }
 }


### PR DESCRIPTION
This pull request significantly refactors this program by removing the AudioPlayer struct, and replacing it with an audio loop that listens to an mpsc channel. When it receives an input, it matches it with the two status types, and if not it passes it to the play_audio function. 
It also passes the response from GET ing the URL directly to the Decoder function (well, nearly directly, since it has to be wrapped in Cursor). 
It also uses Result for all functions instead of unwrapping and expecting every Option/Result. This allows the code to be much more concise, since all you need to use is the ? operator to unwrap a Result.
These changes allow the program to significantly cut down on code and program size due to removing unnecessary code and reducing the amount of unnecessary dependencies used.

(Also, the reason audio was broken in the first place was because you returned Sink from a function. Instead of doing that I built Sink in the websocket_connect function, then allowed audio_loop to take ownership of Sink)