### PR TITLE
use clap's derive macro and remove unnecessary code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ serde_json = "1.0.105"
 rodio = "0.17.1"
 reqwest = "0.11.20"
 anyhow = "1.0.96"
-clap = "4.5.31"
+clap = {version = "4.5.31", features = ["derive"]}

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -15,14 +15,14 @@ pub async fn audio_loop(mut rx: Receiver<String>, sink: Sink) -> Result<(), Erro
             "left" => sink.stop(),
             _ => {
                 sink.set_volume(default_volume);
-                play_audio(input, &client, &sink).await?}
-            ,
+                play_audio(input, &client, &sink).await?;
+            },
         }
     }
 }
 
 pub async fn play_audio(url: String, client: &Client, sink: &Sink) -> Result<(), Error> {
-    println!("\nGot request to play audio {}", url);
+    println!("Got request to play audio {}", url);
     // Stop the current playback, if any
     sink.stop();
 


### PR DESCRIPTION
This commit again cuts down on code size by using clap's derive macro feature which allows the arguments to be specified inside of a struct as opposed to manually building it. This also uses the clamp method on the volume passed through the command line to achieve basically the same thing with less lines of code. Also reads the response from the server in a String instead of a Vec<u8>, allowing the json_processor::process_data function to receive it directly.