### PR TITLE
add support for volume tuning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ rodio = "0.17.1"
 reqwest = "0.11.20"
 anyhow = "1.0.96"
 clap = {version = "4.5.31", features = ["derive"]}
+device_query = "3.0.0"

--- a/src/json_processor.rs
+++ b/src/json_processor.rs
@@ -35,7 +35,7 @@ async fn get_audio(p_data: MessageFormat, tx: &Sender<String>) -> Result<(), Err
     Ok(())
 }
 
-async fn get_status(p_data: MessageFormat, tx:& Sender<String>) -> Result<(), Error> {
+async fn get_status(p_data: MessageFormat, tx: &Sender<String>) -> Result<(), Error> {
     let status_type = p_data.status_type
         .context("msgType was gameStatus but no status was provided")?;
     tx.send(status_type).await?;

--- a/src/json_processor.rs
+++ b/src/json_processor.rs
@@ -11,7 +11,7 @@ struct MessageFormat {
     audio_url: Option<String>,
 }
 
-pub async fn process_data(data: &str, tx: Sender<String>) -> Result<(), Error> {
+pub async fn process_data(data: &str, tx: &Sender<String>) -> Result<(), Error> {
     let p_data: MessageFormat = match serde_json::from_str(data) {
         Ok(parsed_data) => parsed_data,
         Err(err) => {
@@ -28,14 +28,14 @@ pub async fn process_data(data: &str, tx: Sender<String>) -> Result<(), Error> {
     Ok(())
 }
 
-async fn get_audio(p_data: MessageFormat, tx: Sender<String>) -> Result<(), Error> {
+async fn get_audio(p_data: MessageFormat, tx: &Sender<String>) -> Result<(), Error> {
     let audio_url = p_data.audio_url
         .context("msgType was bgm but no URL was provided")?;
     tx.send(audio_url).await?;
     Ok(())
 }
 
-async fn get_status(p_data: MessageFormat, tx: Sender<String>) -> Result<(), Error> {
+async fn get_status(p_data: MessageFormat, tx:& Sender<String>) -> Result<(), Error> {
     let status_type = p_data.status_type
         .context("msgType was gameStatus but no status was provided")?;
     tx.send(status_type).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,26 @@ pub mod json_processor;
 
 use anyhow::{Context, Error};
 use clap::Parser;
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{
+    SinkExt, 
+    StreamExt,
+    stream::SplitStream,
+};
 use rodio::{OutputStream, Sink};
 use std::io::Write;
-use tokio::sync::mpsc::channel;
-use tokio::task;
-use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+use tokio::{
+    sync::mpsc::{Sender, channel},
+    net::TcpStream,
+    time::{sleep, Duration},
+    task,
+};
+use tokio_tungstenite::{
+    connect_async, 
+    MaybeTlsStream,
+    WebSocketStream,
+    tungstenite::protocol::Message,
+};
+use device_query::{DeviceQuery, DeviceState, Keycode};
 
 /// A miniaturized version of FE2.IO written in Rust, and independent of any web browsers.
 #[derive(Parser, Clone)]
@@ -41,26 +55,41 @@ async fn main() -> Result<(), Error> {
     // Check for volume
     let volume = args.volume.clamp(0.0, 100.0) / 100.0; // clamp volume between 0% and 100%
 
-    websocket_connect(username, volume).await?;
+    // Create a connection to the server
+    let read = websocket_connect(username).await?;
+
+    // Create an mpsc channel for communication between the JSON processor and the audio loop
+    let (tx, rx) = channel(32);
+    let (volume_tx, volume_rx) = channel(4);
+
+    // Create Sink for audio device and set volume to the volume passed in argument
+    let (_stream, stream_handle) = OutputStream::try_default()?;
+    let sink = Sink::try_new(&stream_handle)?;
+    sink.set_volume(volume);
+
+    // Spawn separate task for handling audio events
+    task::spawn(audio::audio_loop(rx, volume_rx, sink));
+    // Spawn separate task for handling websocket events
+    task::spawn(websocket_loop(tx.clone(), read));
+
+    keybind_listen(tx, volume_tx, volume).await?;
     Ok(())
 }
 
-async fn websocket_connect(username: String, volume: f32) -> Result<(), Error> {
-    // this does way more than websocket connect lol
+async fn websocket_connect(username: String) -> Result<SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>, Error> {
+    // this does a reasonable amount of work for websocket connect
     let (ws_stream, _response) = connect_async("ws://client.fe2.io:8081").await?;
     println!("Connection established");
 
-    let (mut write, mut read) = ws_stream.split();
+    let (mut write, read) = ws_stream.split();
     write.send(Message::Text(username)).await?;
 
     println!("Sent username to server");
 
-    let (tx, rx) = channel(2);
-    let (_stream, stream_handle) = OutputStream::try_default()?;
-    let sink = Sink::try_new(&stream_handle)?;
-    sink.set_volume(volume);
-    task::spawn(audio::audio_loop(rx, sink));
+    Ok(read)
+}
 
+async fn websocket_loop(tx: Sender<String>, mut read: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>) -> Result<(), Error> {
     loop {
         let message = read
             .next()
@@ -68,6 +97,45 @@ async fn websocket_connect(username: String, volume: f32) -> Result<(), Error> {
             .context("Couldn't receive messages from server")?;
         let data = message?.into_text()?;
         println!("Got message {}", data);
-        json_processor::process_data(&data, tx.clone()).await?;
+        json_processor::process_data(&data, &tx).await?;
+    }
+}
+
+async fn keybind_listen(tx: Sender<String>, volume_tx: Sender<f32>, mut volume: f32) -> Result<(), Error> {
+    let device_state = DeviceState::new();
+    let mut initial_volume = volume;
+    let mut muted = false;
+    loop {
+        let keys: Vec<Keycode> = device_state.get_keys();
+        match keys {
+            keys if keys.contains(&Keycode::Equal) => {
+                volume = (((volume * 100.0) + 5.0).min(100.0).round()) / 100.0;
+                volume_tx.send(volume).await?; // Increase volume
+                tx.send("volume".to_owned()).await?; // Send volume event to audio loop
+                muted = false;
+            },
+            keys if keys.contains(&Keycode::Minus) => {
+                volume = (((volume * 100.0) - 5.0).max(0.0).round()) / 100.0;
+                volume_tx.send(volume).await?; // Lower volume
+                tx.send("volume".to_owned()).await?;
+                muted = false;
+            },
+            keys if keys.contains(&Keycode::Grave) => { // this key `
+                if muted {
+                    volume = initial_volume;
+                    volume_tx.send(volume).await?; // Unmute (sets volume to value before muted)
+                    tx.send("volume".to_owned()).await?;
+                    muted = false;
+                } else {
+                    initial_volume = volume; // Save initial volume in variable
+                    volume = 0.0;
+                    volume_tx.send(volume).await?; // Mute
+                    tx.send("volume".to_owned()).await?;
+                    muted = true;
+                }
+            },
+            _ => (),
+        }
+        sleep(Duration::from_millis(100)).await; // sleep for 100 ms to avoid maxing out the cpu
     }
 }


### PR DESCRIPTION
This commit adds support for tuning volume by increments of 5% using the minus (-) and equals (=) key. It also adds support for muting using the backtick/grave (`) key. This is possible by using the device_query crate and polling the terminal for inputs every 100ms. (On linux at least) it only works while the window is in focus. Since the Sink is owned by the audio_loop function, the volume can't be changed by the keybind_listen function itself. This is fixed by using a mpsc separate channel (volume_tx, volume_rx) and adding a new internal event "volume" that changes the volume to the value inside volume_rx.
Beyond that feature however this commit also moves the websocket listener loop outside of the websocket_connect function to move some functionality to a more appropriately named place, and changes the json_processor::process_data function to borrow instead of owning a clone of tx.