### PR TITLE
implement CLI that allows user to see volume and audio related status and add server argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,23 @@ cd mini-fe2io
 ```
 
 ## Build with Cargo
+### Release builds
+```shell
+cargo build --release
+```
+
+### Debug builds
 ```shell
 cargo build
 ```
 
 ## Run with Cargo
+### Release builds
+```shell
+cargo run --release
+```
+
+### Debug builds
 ```shell
 cargo run
 ```

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -58,7 +58,8 @@ async fn play_audio(url: &str, client: &Client, sink: &Sink) -> Result<(), Error
 }
 
 fn update_audio_status(volume: f32, status: &str) -> Result<(), Error> {
-    print!("{esc}[2J{esc}[1;1H", esc = 27 as char);
+    #[cfg(not(debug_assertions))] // Only clear screen in case debug is disabled
+    print!("{esc}[2J{esc}[1;1H", esc = 27 as char); // clear screen in release builds
     println!("Status: {}", status);
     println!("Volume: {}", volume * 100.0);
     Ok(())

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use std::io::{Cursor, stdout, Write};
 use tokio::sync::mpsc::Receiver;
 use reqwest::Client;
 use rodio::{Decoder, Sink};
@@ -16,19 +16,26 @@ pub async fn audio_loop(mut rx: Receiver<String>, mut volume_rx: Receiver<f32>, 
                     .context("Received volume from keybind listener was not of type f32")?; // this shouldnt ever happen
                 sink.set_volume(received_volume);
                 volume = received_volume;
-                println!("Volume set to {}", volume * 100.0);
+                update_audio_status(volume, "Changed volume")?;
             },
-            "died" => sink.set_volume(volume / 2.0),
-            "left" => sink.stop(),
+            "died" => {
+                sink.set_volume(volume / 2.0);
+                update_audio_status(volume / 2.0, "Player died, setting volume to 0")?;
+            },
+            "left" => { 
+                sink.stop();
+                update_audio_status(volume, "Player left the game, stopping audio output")?;
+            },
             _ => {
                 sink.set_volume(volume);
-                play_audio(input, &client, &sink).await?;
+                play_audio(&input, &client, &sink).await?;
+                update_audio_status(volume, &format!("Currently playing URL {}", input))?;
             },
         }
     }
 }
 
-pub async fn play_audio(url: String, client: &Client, sink: &Sink) -> Result<(), Error> {
+async fn play_audio(url: &str, client: &Client, sink: &Sink) -> Result<(), Error> {
     println!("Got request to play audio {}", url);
     // Stop the current playback, if any
     sink.stop();
@@ -47,5 +54,12 @@ pub async fn play_audio(url: String, client: &Client, sink: &Sink) -> Result<(),
     let decoder = Decoder::new(cursor)?;
     sink.append(decoder);
     println!("Playback started");
+    Ok(())
+}
+
+fn update_audio_status(volume: f32, status: &str) -> Result<(), Error> {
+    print!("{esc}[2J{esc}[1;1H", esc = 27 as char);
+    println!("Status: {}", status);
+    println!("Volume: {}", volume * 100.0);
     Ok(())
 }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -16,20 +16,20 @@ pub async fn audio_loop(mut rx: Receiver<String>, mut volume_rx: Receiver<f32>, 
                     .context("Received volume from keybind listener was not of type f32")?; // this shouldnt ever happen
                 sink.set_volume(received_volume);
                 volume = received_volume;
-                update_audio_status(volume, "Changed volume")?;
+                update_audio_status(volume, "Changed volume");
             },
             "died" => {
                 sink.set_volume(volume / 2.0);
-                update_audio_status(volume / 2.0, "Player died, setting volume to 0")?;
+                update_audio_status(volume / 2.0, &format!("Player died, setting volume to {}", volume * 100.0 / 2.0));
             },
             "left" => { 
                 sink.stop();
-                update_audio_status(volume, "Player left the game, stopping audio output")?;
+                update_audio_status(volume, "Player left the game, stopping audio output");
             },
             _ => {
                 sink.set_volume(volume);
                 play_audio(&input, &client, &sink).await?;
-                update_audio_status(volume, &format!("Currently playing URL {}", input))?;
+                update_audio_status(volume, &format!("Currently playing URL {}", input));
             },
         }
     }
@@ -57,10 +57,9 @@ async fn play_audio(url: &str, client: &Client, sink: &Sink) -> Result<(), Error
     Ok(())
 }
 
-fn update_audio_status(volume: f32, status: &str) -> Result<(), Error> {
+fn update_audio_status(volume: f32, status: &str) {
     #[cfg(not(debug_assertions))] // Only clear screen in case debug is disabled
     print!("{esc}[2J{esc}[1;1H", esc = 27 as char); // clear screen in release builds
     println!("Status: {}", status);
     println!("Volume: {}", volume * 100.0);
-    Ok(())
 }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, stdout, Write};
+use std::io::Cursor;
 use tokio::sync::mpsc::Receiver;
 use reqwest::Client;
 use rodio::{Decoder, Sink};

--- a/src/keybind.rs
+++ b/src/keybind.rs
@@ -1,0 +1,45 @@
+use tokio::{
+    time::{sleep, Duration},
+    sync::mpsc::Sender,
+};
+use device_query::{DeviceQuery, DeviceState, Keycode};
+use anyhow::Error;
+
+pub async fn keybind_listen(tx: Sender<String>, volume_tx: Sender<f32>, mut volume: f32) -> Result<(), Error> { // MASSIVE function
+    let device_state = DeviceState::new();
+    let mut initial_volume = volume;
+    let mut muted = false;
+    loop {
+        let keys: Vec<Keycode> = device_state.get_keys();
+        match keys {
+            keys if keys.contains(&Keycode::Equal) => {
+                volume = (((volume * 100.0) + 5.0).min(100.0).round()) / 100.0;
+                volume_tx.send(volume).await?; // Increase volume
+                tx.send("volume".to_owned()).await?; // Send volume event to audio loop
+                muted = false;
+            },
+            keys if keys.contains(&Keycode::Minus) => {
+                volume = (((volume * 100.0) - 5.0).max(0.0).round()) / 100.0;
+                volume_tx.send(volume).await?; // Lower volume
+                tx.send("volume".to_owned()).await?;
+                muted = false;
+            },
+            keys if keys.contains(&Keycode::Grave) => { // this key `
+                if muted {
+                    volume = initial_volume;
+                    volume_tx.send(volume).await?; // Unmute (sets volume to value before muted)
+                    tx.send("volume".to_owned()).await?;
+                    muted = false;
+                } else {
+                    initial_volume = volume; // Save initial volume in variable
+                    volume = 0.0;
+                    volume_tx.send(volume).await?; // Mute
+                    tx.send("volume".to_owned()).await?;
+                    muted = true;
+                }
+            },
+            _ => (),
+        }
+        sleep(Duration::from_millis(100)).await; // sleep for 100 ms to avoid maxing out the cpu
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ struct Args {
     /// Volume
     #[arg(short = 'v', long = "volume", default_value_t = 70.0)]
     volume: f32,
+    /// Server
+    #[arg(short = 's', long = "server", default_value = "ws://client.fe2.io:8081")]
+    server: String,
 }
 
 #[tokio::main]
@@ -55,7 +58,7 @@ async fn main() -> Result<(), Error> {
     let volume = args.volume.clamp(0.0, 100.0) / 100.0; // clamp volume between 0% and 100%
 
     // Create a connection to the server
-    let read = websocket_connect(username).await?;
+    let read = websocket_connect(args.server, username).await?;
 
     // Create an mpsc channel for communication between the JSON processor and the audio loop
     let (tx, rx) = channel(32);
@@ -75,9 +78,9 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-async fn websocket_connect(username: String) -> Result<SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>, Error> {
+async fn websocket_connect(server: String, username: String) -> Result<SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>, Error> {
     // this does a reasonable amount of work for websocket connect
-    let (ws_stream, _response) = connect_async("ws://client.fe2.io:8081").await?;
+    let (ws_stream, _response) = connect_async(server).await?;
     println!("Connection established");
 
     let (mut write, read) = ws_stream.split();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod audio;
-pub mod json_processor;
+mod keybind;
+mod json_processor;
 
 use anyhow::{Context, Error};
 use clap::Parser;
@@ -13,7 +14,6 @@ use std::io::Write;
 use tokio::{
     sync::mpsc::{Sender, channel},
     net::TcpStream,
-    time::{sleep, Duration},
     task,
 };
 use tokio_tungstenite::{
@@ -22,7 +22,6 @@ use tokio_tungstenite::{
     WebSocketStream,
     tungstenite::protocol::Message,
 };
-use device_query::{DeviceQuery, DeviceState, Keycode};
 
 /// A miniaturized version of FE2.IO written in Rust, and independent of any web browsers.
 #[derive(Parser, Clone)]
@@ -72,7 +71,7 @@ async fn main() -> Result<(), Error> {
     // Spawn separate task for handling websocket events
     task::spawn(websocket_loop(tx.clone(), read));
 
-    keybind_listen(tx, volume_tx, volume).await?;
+    keybind::keybind_listen(tx, volume_tx, volume).await?;
     Ok(())
 }
 
@@ -98,44 +97,5 @@ async fn websocket_loop(tx: Sender<String>, mut read: SplitStream<WebSocketStrea
         let data = message?.into_text()?;
         println!("Got message {}", data);
         json_processor::process_data(&data, &tx).await?;
-    }
-}
-
-async fn keybind_listen(tx: Sender<String>, volume_tx: Sender<f32>, mut volume: f32) -> Result<(), Error> {
-    let device_state = DeviceState::new();
-    let mut initial_volume = volume;
-    let mut muted = false;
-    loop {
-        let keys: Vec<Keycode> = device_state.get_keys();
-        match keys {
-            keys if keys.contains(&Keycode::Equal) => {
-                volume = (((volume * 100.0) + 5.0).min(100.0).round()) / 100.0;
-                volume_tx.send(volume).await?; // Increase volume
-                tx.send("volume".to_owned()).await?; // Send volume event to audio loop
-                muted = false;
-            },
-            keys if keys.contains(&Keycode::Minus) => {
-                volume = (((volume * 100.0) - 5.0).max(0.0).round()) / 100.0;
-                volume_tx.send(volume).await?; // Lower volume
-                tx.send("volume".to_owned()).await?;
-                muted = false;
-            },
-            keys if keys.contains(&Keycode::Grave) => { // this key `
-                if muted {
-                    volume = initial_volume;
-                    volume_tx.send(volume).await?; // Unmute (sets volume to value before muted)
-                    tx.send("volume".to_owned()).await?;
-                    muted = false;
-                } else {
-                    initial_volume = volume; // Save initial volume in variable
-                    volume = 0.0;
-                    volume_tx.send(volume).await?; // Mute
-                    tx.send("volume".to_owned()).await?;
-                    muted = true;
-                }
-            },
-            _ => (),
-        }
-        sleep(Duration::from_millis(100)).await; // sleep for 100 ms to avoid maxing out the cpu
     }
 }


### PR DESCRIPTION
This commit adds support for a super super basic non interactive "CLI" that shows the user the Volume and the status. This includes, for example, what audio is playing, or if the volume was changed, or if the player died or left the game. This commit also adds the "server" argument for partial feature parity with fe2io-python, which had a server feature (though it was rather inflexible, having only support for fe2io and lbio)