### PR TITLE
add audio caching and skipping duration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ reqwest = "0.11.20"
 anyhow = "1.0.96"
 clap = {version = "4.5.31", features = ["derive"]}
 device_query = "3.0.0"
+dirs = "6.0.0"

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,58 +1,101 @@
-use std::io::Cursor;
-use tokio::sync::mpsc::Receiver;
+use anyhow::{Context, Error, bail};
 use reqwest::Client;
-use rodio::{Decoder, Sink};
-use anyhow::{Context, Error};
+use rodio::{Decoder, Sink, Source};
+use std::{io::Cursor, path::Path};
+use tokio::{
+    fs::{File, create_dir_all},
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::mpsc::Receiver,
+    time::Instant,
+};
 
-pub async fn audio_loop(mut rx: Receiver<String>, mut volume_rx: Receiver<f32>, sink: Sink) -> Result<(), Error> {
+pub async fn audio_loop(
+    mut rx: Receiver<String>,
+    mut volume_rx: Receiver<f32>,
+    sink: Sink,
+) -> Result<(), Error> {
     let client = Client::new();
     let mut volume = sink.volume();
     loop {
-        let input = rx.recv().await
-            .context("Audio channel closed")?;
+        let input = rx.recv().await.context("Audio channel closed")?;
         match input.as_str() {
-            "volume" => { // internal event
-                let received_volume = volume_rx.recv().await // this shouldn't stall the audio loop since volume_rx should already have a message by the time volume is received
+            "volume" => {
+                // internal event
+                let received_volume = volume_rx
+                    .recv()
+                    .await // this shouldn't stall the audio loop since volume_rx should already have a message by the time volume is received
                     .context("Received volume from keybind listener was not of type f32")?; // this shouldnt ever happen
                 sink.set_volume(received_volume);
                 volume = received_volume;
                 update_audio_status(volume, "Changed volume");
-            },
+            }
             "died" => {
                 sink.set_volume(volume / 2.0);
-                update_audio_status(volume / 2.0, &format!("Player died, setting volume to {}", volume * 100.0 / 2.0));
-            },
-            "left" => { 
+                update_audio_status(
+                    volume / 2.0,
+                    &format!("Player died, setting volume to {}", volume * 100.0 / 2.0),
+                );
+            }
+            "left" => {
                 sink.stop();
                 update_audio_status(volume, "Player left the game, stopping audio output");
-            },
+            }
             _ => {
                 sink.set_volume(volume);
                 play_audio(&input, &client, &sink).await?;
-                update_audio_status(volume, &format!("Currently playing URL {}", input));
-            },
+                update_audio_status(volume, &format!("Currently playing URL {input}"));
+            }
         }
     }
 }
 
 async fn play_audio(url: &str, client: &Client, sink: &Sink) -> Result<(), Error> {
-    println!("Got request to play audio {}", url);
+    println!("Got request to play audio {url}");
     // Stop the current playback, if any
     sink.stop();
 
-    // Get response from URL
-    let response = client.get(url)
-        .send()
-        .await?
-        .bytes()
-        .await?;
+    // Get the user's home directory, and create the fe2io-cache directory
+    let home = dirs::home_dir() // get home dir
+        .context("No home directory was found")? // unwrap Option from home dir
+        .to_str() // convert returned PathBuf to str
+        .context("Home directory that was returned wasn't a string")? // unwrap Option from str
+        .to_owned(); // convert str to owned String
 
-    println!("Got response");
+    let cache = format!("{home}/fe2io-cache"); // get fe2io-cache as a string
+    create_dir_all(cache.clone()).await?; // if fe2io-cache doesn't exist, create it
 
+    let file_as_str = format!("{cache}/{url}"); // get file location as a string
+    let file = Path::new(&file_as_str); // get file location as a Path
+    let start = Instant::now(); // Get the Instant before downloading or reading the audio
+
+    let audio = if let Ok(false) = file.try_exists() {
+        // checks if file does not exist
+        // Get response from URL
+        let response = client.get(url).send().await?.bytes().await?.to_vec(); // convert to vec so that the arms are the same types
+
+        println!("Got response");
+
+        // Create a file inside of fe2io-cache, then write the content of Response to it
+        let mut f = File::create(file).await?;
+        f.write_all(&response).await?;
+
+        // Wrap the response in a Cursor to implement Seek and Read
+        Cursor::new(response)
+    } else if let Ok(true) = file.try_exists() {
+        // checks if file does exist and is readable
+        let mut f = File::open(file).await?;
+        let mut buf = Vec::new();
+
+        f.read_to_end(&mut buf).await?;
+        Cursor::new(buf)
+    } else {
+        // this is probably because there are no permissions to read from home directory
+        bail!("Unable to verify if fe2io-cache dir in home directory exists");
+    };
     // Play the downloaded audio
-    let cursor = Cursor::new(response);
-    let decoder = Decoder::new(cursor)?;
-    sink.append(decoder);
+    let decoder = Decoder::new(audio)?;
+    let elapsed = Instant::now().duration_since(start);
+    sink.append(decoder.skip_duration(elapsed));
     println!("Playback started");
     Ok(())
 }
@@ -60,6 +103,6 @@ async fn play_audio(url: &str, client: &Client, sink: &Sink) -> Result<(), Error
 fn update_audio_status(volume: f32, status: &str) {
     #[cfg(not(debug_assertions))] // Only clear screen in case debug is disabled
     print!("{esc}[2J{esc}[1;1H", esc = 27 as char); // clear screen in release builds
-    println!("Status: {}", status);
+    println!("Status: {status}");
     println!("Volume: {}", volume * 100.0);
 }

--- a/src/json_processor.rs
+++ b/src/json_processor.rs
@@ -15,7 +15,7 @@ pub async fn process_data(data: &str, tx: &Sender<String>) -> Result<(), Error> 
     let p_data: MessageFormat = match serde_json::from_str(data) {
         Ok(parsed_data) => parsed_data,
         Err(err) => {
-            eprintln!("Error parsing JSON: {}", err);
+            eprintln!("Error parsing JSON: {err}");
             return Err(err.into()); // Exit early on error
         }
     };

--- a/src/keybind.rs
+++ b/src/keybind.rs
@@ -1,11 +1,16 @@
-use tokio::{
-    time::{sleep, Duration},
-    sync::mpsc::Sender,
-};
-use device_query::{DeviceQuery, DeviceState, Keycode};
 use anyhow::Error;
+use device_query::{DeviceQuery, DeviceState, Keycode};
+use tokio::{
+    sync::mpsc::Sender,
+    time::{Duration, sleep},
+};
 
-pub async fn keybind_listen(tx: Sender<String>, volume_tx: Sender<f32>, mut volume: f32) -> Result<(), Error> { // MASSIVE function
+pub async fn keybind_listen(
+    tx: Sender<String>,
+    volume_tx: Sender<f32>,
+    mut volume: f32,
+) -> Result<(), Error> {
+    // MASSIVE function
     let device_state = DeviceState::new();
     let mut initial_volume = volume;
     let mut muted = false;
@@ -17,14 +22,15 @@ pub async fn keybind_listen(tx: Sender<String>, volume_tx: Sender<f32>, mut volu
                 volume_tx.send(volume).await?; // Increase volume
                 tx.send("volume".to_owned()).await?; // Send volume event to audio loop
                 muted = false;
-            },
+            }
             keys if keys.contains(&Keycode::Minus) => {
                 volume = (((volume * 100.0) - 5.0).max(0.0).round()) / 100.0;
                 volume_tx.send(volume).await?; // Lower volume
                 tx.send("volume".to_owned()).await?;
                 muted = false;
-            },
-            keys if keys.contains(&Keycode::Grave) => { // this key `
+            }
+            keys if keys.contains(&Keycode::Grave) => {
+                // this key `
                 if muted {
                     volume = initial_volume;
                     volume_tx.send(volume).await?; // Unmute (sets volume to value before muted)
@@ -37,7 +43,7 @@ pub async fn keybind_listen(tx: Sender<String>, volume_tx: Sender<f32>, mut volu
                     tx.send("volume".to_owned()).await?;
                     muted = true;
                 }
-            },
+            }
             _ => (),
         }
         sleep(Duration::from_millis(100)).await; // sleep for 100 ms to avoid maxing out the cpu

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ async fn websocket_loop(tx: Sender<String>, mut read: SplitStream<WebSocketStrea
             .await
             .context("Couldn't receive messages from server")?;
         let data = message?.into_text()?;
-        println!("Got message {}", data);
+        println!("Got message {data}");
         json_processor::process_data(&data, &tx).await?;
     }
 }


### PR DESCRIPTION
Adds support for audio caching. This saves audio into a directory in your home directory called fe2io-cache. The files are saved according to the URL, which is very similar to fe2io-python's audio caching feature. What makes it different however is that rodio doesn't rely on the file extension to decode audio, which allows foregoing a JSON dictionary and simply reading the files as they are.
This also adds support for skipping duration.